### PR TITLE
Added auth-icons.png to the precompile array.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,8 @@ module Cfp
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
     config.i18n.enforce_available_locales = true
+
+    config.assets.precompile += %w( auth-icons.png )
   end
 end
 


### PR DESCRIPTION
Turns out vendor/assets is not added to the precompile array by default
in rails 4.

http://guides.rubyonrails.org/asset_pipeline.html#asset-organization

This should close #19 
