### PR TITLE
Redirect back to listing after voting for convenience.

### DIFF
--- a/app/controllers/admin/user_paper_ratings_controller.rb
+++ b/app/controllers/admin/user_paper_ratings_controller.rb
@@ -5,7 +5,7 @@ class Admin::UserPaperRatingsController < Admin::AdminController
   def create
     @user_paper_rating.assign_attributes(user_paper_rating_params)
     if @user_paper_rating.save then
-      redirect_to @paper, notice: "voting successful!"
+      redirect_to admin_papers_path, notice: "voting successful!"
     else
       render "papers/show"
     end


### PR DESCRIPTION
This may be a personal preference, but after voting I’d like to go back directly to the papers listing. 
