### PR TITLE
Add a rank number to the paper table

### DIFF
--- a/app/views/admin/papers/index.html.erb
+++ b/app/views/admin/papers/index.html.erb
@@ -21,7 +21,7 @@
     <table class="table table-header-rotated">
       <thead>
         <tr>
-          <th><%= t('activerecord.models.attributes.paper.rank') %></th>
+          <th><%= t('activerecord.models.attributes.paper.position') %></th>
           <th><%= t('activerecord.models.attributes.paper.time_slot') %></th>
           <th><%= t('activerecord.models.attributes.paper.id') %></th>
           <th><%= t('activerecord.models.attributes.paper.title') %></th>


### PR DESCRIPTION
This allows us to quickly gauge

a) where we are on the unsorted page
b) The rank of the paper on the sorted by score page for later cut-off
