### PR TITLE
Deactivate the Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-branches:
-  only:
-    - master
-before_script: cp config/database.yml.example config/database.yml
-language: ruby
-rvm:
-  - 2.1.4
-script: bundle exec rake db:create db:migrate db:test:prepare default

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eurucamp Call for Papers
   [![License](http://img.shields.io/:license-AGPL-0030c8.svg)](COPYRIGHT)
-  [![Build Status](https://travis-ci.org/eurucamp/call4papers.png?branch=master)](https://travis-ci.org/eurucamp/call4papers)[![Codeship Status](https://codeship.com/projects/2f6136b0-643a-0132-16ea-6e8486426495/status?branch=bump)]
+  [![Codeship Status](https://codeship.com/projects/2f6136b0-643a-0132-16ea-6e8486426495/status?branch=bump)]
 
 The eurucamp Call for Papers application allows users to submit conference proposals or suggest speakers. Signup works through Github or Twitter.
 


### PR DESCRIPTION
No need to eat away precious OSS Travis minutes when we have Codeship.
Sadly this build is broken by definition. :baby_chick: 
