### PR TITLE
Let the database sum up votes on admin paper overview

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -10,6 +10,7 @@ class Paper < ActiveRecord::Base
   belongs_to :user
   belongs_to :call
   has_many :user_paper_ratings, inverse_of: :paper, dependent: :destroy
+  has_many :ratings, through: :user_paper_ratings
 
   validates :id, :title, :public_description, :time_slot, presence: true
   validates :call, :user, presence: true
@@ -45,13 +46,13 @@ class Paper < ActiveRecord::Base
   end
 
   def score
-    user_paper_ratings.to_a.sum(&:sum) / user_paper_ratings.count.to_f
+    sum_of_votes = ratings.sum(:vote)
+    sum_of_votes / user_paper_ratings.size.to_f
   end
 
   def score_by_dimension(dimension)
-    user_paper_ratings.to_a.sum do |ur|
-      ur.rating_for_rating_dimension(dimension).vote
-    end / user_paper_ratings.count.to_f
+    sum_of_votes = ratings.in_dimension(dimension).sum(:vote)
+    sum_of_votes / user_paper_ratings.size.to_f
   end
 
   class << self

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -5,4 +5,6 @@ class Rating < ActiveRecord::Base
   validates_presence_of :user_paper_rating, :rating_dimension, :vote
   validates_uniqueness_of :rating_dimension_id, scope: :user_paper_rating_id
   validates_numericality_of :vote, greater_than_or_equal_to: 0, less_than_or_equal_to: 2
+
+  scope :in_dimension, -> dimension { where(rating_dimension_id: dimension) }
 end

--- a/app/models/user_paper_rating.rb
+++ b/app/models/user_paper_rating.rb
@@ -8,16 +8,6 @@ class UserPaperRating < ActiveRecord::Base
 
   accepts_nested_attributes_for :ratings
 
-  def sum
-    ratings.to_a.sum(&:vote)
-  end
-
-  def rating_for_rating_dimension(dimension)
-    dimension_id = dimension.is_a?(RatingDimension) ? dimension.id : dimension
-    rating = self.ratings.find{|rating| rating.rating_dimension_id == dimension_id }
-    rating ||= self.ratings.new(rating_dimension_id: dimension_id)
-  end
-
 private
   def call_must_be_closed
     errors.add(:paper, 'Paper call must be closed!') if paper.try(:call_open?)


### PR DESCRIPTION
This keeps the number of queries low when there are many ratings.
Instead of fetching each rating individually into memory and summing up
the votes, this directly gets the sum of votes for a paper.