### PR TITLE
Remove Workshop option

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -14,7 +14,6 @@ defaults: &defaults
       - 15 minutes
       - 30 minutes
       - 40 minutes
-      - workshop
   conferences:
     - eurucamp
     - jrubyconf


### PR DESCRIPTION
We don't offer workshops this year. Remove it from the selection.