### PR TITLE
Add missing unicorn dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'jquery-rails',     '~> 3.1.0'
 
 gem 'rack-robotz',      '~> 0.0.3'
 gem 'localeapp'
+gem 'unicorn'
 
 group :development do
   gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.2)
     jwt (1.2.0)
+    kgio (2.9.3)
     localeapp (0.9.0)
       gli
       i18n
@@ -176,6 +177,7 @@ GEM
       activesupport (= 4.2.0)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    raindrops (0.13.0)
     rake (10.4.2)
     redcarpet (3.2.2)
     responders (2.0.2)
@@ -223,6 +225,10 @@ GEM
     uglifier (2.7.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    unicorn (4.8.3)
+      kgio (~> 2.6)
+      rack
+      raindrops (~> 0.7)
     warden (1.2.3)
       rack (>= 1.0)
     web-console (2.0.0)
@@ -264,4 +270,5 @@ DEPENDENCIES
   simplecov
   thin
   uglifier (>= 1.0.3)
+  unicorn
   web-console (~> 2.0)


### PR DESCRIPTION
I try:

```bash
$ bundle install
$ bundle exec foreman start
```
Then foreman complains that `unicorn` is not installed. So I added this to the `Gemfile`.