### PR TITLE
Remove JS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,12 +24,8 @@ gem 'thin'
 
 gem 'sass-rails',       '~> 5.0.0'
 gem 'foundation-rails', '~> 5.4.0'
-gem 'coffee-rails',     '~> 4.1.0'
-gem 'uglifier',         '>= 1.0.3'
 gem 'font-awesome-sass'
 gem 'bourbon'
-
-gem 'jquery-rails',     '~> 3.1.0'
 
 gem 'rack-robotz',      '~> 0.0.3'
 gem 'localeapp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,13 +44,6 @@ GEM
       sass (~> 3.3)
       thor
     builder (3.2.2)
-    coffee-rails (4.1.0)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0, < 5.0)
-    coffee-script (2.3.0)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.8.0)
     daemons (1.1.9)
     debug_inspector (0.0.2)
     devise (3.4.1)
@@ -71,7 +64,6 @@ GEM
     exception_notification (4.0.1)
       actionmailer (>= 3.0.4)
       activesupport (>= 3.0.4)
-    execjs (2.2.2)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
     font-awesome-sass (4.2.2)
@@ -90,9 +82,6 @@ GEM
     i18n (0.7.0)
     immigrant (0.2.0)
       activerecord (>= 3.0)
-    jquery-rails (3.1.2)
-      railties (>= 3.0, < 5.0)
-      thor (>= 0.14, < 2.0)
     json (1.8.2)
     jwt (1.2.0)
     localeapp (0.9.0)
@@ -220,9 +209,6 @@ GEM
     tilt (1.4.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (2.7.0)
-      execjs (>= 0.3.0)
-      json (>= 1.8.0)
     warden (1.2.3)
       rack (>= 1.0)
     web-console (2.0.0)
@@ -237,7 +223,6 @@ PLATFORMS
 
 DEPENDENCIES
   bourbon
-  coffee-rails (~> 4.1.0)
   devise (~> 3.4.1)
   dotenv-deployment
   dotenv-rails
@@ -246,7 +231,6 @@ DEPENDENCIES
   foreman
   foundation-rails (~> 5.4.0)
   immigrant
-  jquery-rails (~> 3.1.0)
   localeapp
   omniauth
   omniauth-github
@@ -263,5 +247,4 @@ DEPENDENCIES
   simple_form (~> 3.1.0)
   simplecov
   thin
-  uglifier (>= 1.0.3)
   web-console (~> 2.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,0 @@
-//= require jquery
-//= require jquery_ujs
-//= require foundation
-
-$(function(){ $(document).foundation(); });

--- a/app/assets/stylesheets/framework_and_overrides.css.scss
+++ b/app/assets/stylesheets/framework_and_overrides.css.scss
@@ -1,4 +1,3 @@
-@import "bourbon";
 @import "fonts";
 
 $body-font-family:   'sonarnormal', sans-serif;

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -7,7 +7,6 @@
     <title><%= content_for?(:title) ? yield(:title) : "Call for Papers | eurucamp" %></title>
 
     <%= stylesheet_link_tag    "application", media: "all" %>
-    <%= javascript_include_tag "vendor/modernizr" %>
     <%= csrf_meta_tags %>
   </head>
   <body class="<%= @conference %>">
@@ -20,7 +19,6 @@
         <%= yield %>
       </div>
     </main>
-    <%= javascript_include_tag "application" %>
     <%= render 'main/footer' %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,6 @@
     <title><%= content_for?(:title) ? yield(:title) : "Call for Papers | eurucamp" %></title>
 
     <%= stylesheet_link_tag    "application", media: "all" %>
-    <%= javascript_include_tag "vendor/modernizr" %>
     <%= csrf_meta_tags %>
   </head>
   <body class="<%= @conference %>">
@@ -21,6 +20,5 @@
       </div>
     </main>
     <%= render 'main/footer' %>
-    <%= javascript_include_tag "application" %>
   </body>
 </html>

--- a/app/views/layouts/welcome.html.erb
+++ b/app/views/layouts/welcome.html.erb
@@ -7,7 +7,6 @@
     <title><%= content_for?(:title) ? yield(:title) : "Call for Papers | eurucamp" %></title>
 
     <%= stylesheet_link_tag    "application", media: "all" %>
-    <%= javascript_include_tag "vendor/modernizr" %>
     <%= csrf_meta_tags %>
   </head>
   <body class="<%= 'frontpage'  if params[:action] ==  'index' %> <%= @conference %>">
@@ -22,7 +21,6 @@
       </div>
     </main>
     <%= render 'main/footer' %>
-    <%= javascript_include_tag "application" %>
     <script type="text/javascript">
       (function(d, s, id) {
       var js, fjs = d.getElementsByTagName(s)[0];


### PR DESCRIPTION
It is not used. We can remove JS, CoffeeScript, Uglifier and jQuery.

Any reasons to keep it? Let's get rid of this stuff.