### PR TITLE
Adjustments to the mentorship text

### DIFF
--- a/app/views/pages/mentorship.html.erb
+++ b/app/views/pages/mentorship.html.erb
@@ -18,10 +18,6 @@
 <p>That would be perfect. Make double sure both or your talks get accepted ;).</p>
 <h3 id="i-cannot-attend-but-would-like-to-help">I cannot attend, but would like to help</h3>
 <p>This is certainly not perfect, but if you want to help a speaker preparing, we will find someone else to help the person on the day of the conference.</p>
-<h3 id="whats-in-for-the-mentors">What's in for the mentors?</h3>
-<p>You will get a preferred slot at ticket sales to make sure that you will be on the conference.</p>
-<p>Because we operate at a very low margin per ticket, we have to be very conscious with monetary incentives.</p>
-<p>You can be sure that we will come up with something special on top.</p>
 <h2 id="speakers">Speakers</h2>
 <p>You will get a mentor assigned, unconditional of whether you feel the need for one. This is to ensure that no one needs to ask for help, but has someone ready the moment they need one.</p>
 <p>Please be aware the mentors are volunteering, so allow for time for review steps and treat their time with respect. Agreeing on a timeline beforehand should be the best solution.</p>

--- a/app/views/pages/mentorship.html.erb
+++ b/app/views/pages/mentorship.html.erb
@@ -1,8 +1,8 @@
-<h1 id="eurucamp-speaker-mentorship">eurucamp Speaker Mentorship</h1>
-<p><strong>tl;dr</strong>: eurucamp has an unconditional speaker mentorship program - everyone will get a mentor assigned.</p>
+<h1 id="eurucamp-speaker-mentorship">Speaker Mentorship</h1>
+<p><strong>tl;dr</strong>: We have an unconditional speaker mentorship program - everyone will get a mentor assigned.</p>
 <p>For that, we need your help.</p>
 <h2 id="goals">Goals</h2>
-<p>eurucamp wants to encourage speakers to try out something new - either by being on stage for the first time or by trying talks in new areas.</p>
+<p>We want to encourage speakers to try out something new - either by being on stage for the first time or by trying talks in new areas.</p>
 <p>We want to make sure that every speaker has someone assigned to turn to in case of questions and problems.</p>
 <h2 id="being-a-mentor">Being a Mentor</h2>
 <h3 id="volunteering-as-a-mentor">Volunteering as a mentor</h3>
@@ -13,14 +13,14 @@
 <p>Expect around 4-5 hours of work per speaker (upper bound).</p>
 <p>It is not your job to fundamentally criticise the idea of a talk - it got accepted for a reason. If you feel that you are not fit for getting behind the topic of a talk at all, please get in contact with us and we assign you another speaker.</p>
 <h3 id="can-speakers-be-mentors">Can speakers be mentors?</h3>
-<p>Sure, if you intend to speak at eurucamp and mentor someone else, be welcome!</p>
+<p>Sure, if you intend to speak at our conference and mentor someone else, be welcome!</p>
 <h3 id="can-we-pair-so-that-we-give-feedback-to-each-other">Can we 'pair', so that we give feedback to each other?</h3>
 <p>That would be perfect. Make double sure both or your talks get accepted ;).</p>
 <h3 id="i-cannot-attend-but-would-like-to-help">I cannot attend, but would like to help</h3>
 <p>This is certainly not perfect, but if you want to help a speaker preparing, we will find someone else to help the person on the day of the conference.</p>
 <h3 id="whats-in-for-the-mentors">What's in for the mentors?</h3>
 <p>You will get a preferred slot at ticket sales to make sure that you will be on the conference.</p>
-<p>Because eurucamp operates at a very low margin per ticket, we have to be very conscious with monetary incentives.</p>
+<p>Because we operate at a very low margin per ticket, we have to be very conscious with monetary incentives.</p>
 <p>You can be sure that we will come up with something special on top.</p>
 <h2 id="speakers">Speakers</h2>
 <p>You will get a mentor assigned, unconditional of whether you feel the need for one. This is to ensure that no one needs to ask for help, but has someone ready the moment they need one.</p>

--- a/app/views/pages/mentorship.html.erb
+++ b/app/views/pages/mentorship.html.erb
@@ -7,10 +7,6 @@
 <h2 id="being-a-mentor">Being a Mentor</h2>
 <h3 id="volunteering-as-a-mentor">Volunteering as a mentor</h3>
 <p>Mentors sign up through <a href="/">our CFP app</a>. Navigate to your profile section and check the mentor box. We will get in contact with you to assign speakers to you. You will also be able to read submissions that are up for review and give feedback.</p>
-<h3 id="proposing-a-speaker">Proposing a speaker</h3>
-<p>You can also propose someone new to speak. Sign up in the CFP app and use the &quot;propose speaker&quot; function. Please make sure that the person has no or low speaking experience.</p>
-<p>That person will be contacted by us. The potential speaker has to go through CFP. <em>By proposing someone, you agree to mentor the person</em>.</p>
-<p>Please be aware that the &quot;propose a speaker&quot; function is not intended as a wishlist.</p>
 <h3 id="the-mentors-job">The Mentors Job</h3>
 <p>Mentors are asked to help speakers to flesh out their talks and bring their ideas on stage. This includes review of slides, hints with design and getting to them and answering any questions the speaker might have. Your role is a reassuring one.</p>
 <p>Also, on the conference, you are expected to watch the talks of you assigned speakers and give feedback afterwards.</p>

--- a/app/views/pages/mentorship.html.erb
+++ b/app/views/pages/mentorship.html.erb
@@ -1,5 +1,5 @@
 <h1 id="eurucamp-speaker-mentorship">eurucamp Speaker Mentorship</h1>
-<p><strong>tl;dr</strong>: eurucamp 2014 has an unconditional speaker mentorship program - everyone will get a mentor assigned.</p>
+<p><strong>tl;dr</strong>: eurucamp has an unconditional speaker mentorship program - everyone will get a mentor assigned.</p>
 <p>For that, we need your help.</p>
 <h2 id="goals">Goals</h2>
 <p>eurucamp wants to encourage speakers to try out something new - either by being on stage for the first time or by trying talks in new areas.</p>
@@ -13,7 +13,7 @@
 <p>Expect around 4-5 hours of work per speaker (upper bound).</p>
 <p>It is not your job to fundamentally criticise the idea of a talk - it got accepted for a reason. If you feel that you are not fit for getting behind the topic of a talk at all, please get in contact with us and we assign you another speaker.</p>
 <h3 id="can-speakers-be-mentors">Can speakers be mentors?</h3>
-<p>Sure, if you intend to speak at eurucamp 2014 and mentor someone else, be welcome!</p>
+<p>Sure, if you intend to speak at eurucamp and mentor someone else, be welcome!</p>
 <h3 id="can-we-pair-so-that-we-give-feedback-to-each-other">Can we 'pair', so that we give feedback to each other?</h3>
 <p>That would be perfect. Make double sure both or your talks get accepted ;).</p>
 <h3 id="i-cannot-attend-but-would-like-to-help">I cannot attend, but would like to help</h3>


### PR DESCRIPTION
* Remove text about proposing speakers, as this feature has been removed as discussed in Slack
* Remove 2014 from the text
* Removed explicit mentioning of eurucamp, using "we" instead, as this CfP has more than one conference
* Removed section about mentorship perks as they are not confirmed