### PR TITLE
Fix migration that moves data from proposals to talks

### DIFF
--- a/db/migrate/20150320202202_move_data_from_proposal_to_talk.rb
+++ b/db/migrate/20150320202202_move_data_from_proposal_to_talk.rb
@@ -12,7 +12,8 @@ class MoveDataFromProposalToTalk < ActiveRecord::Migration
         talk.mentor_name         = proposal.read_attribute :mentor_name
         talk.mentors_can_read    = proposal.read_attribute :mentors_can_read
 
-        talk.save!
+        talk.valid? # Talk#id is generated before_validation…
+        talk.save!(validate: false) # validations complain about too few calls
         proposal.save!
       end
     end


### PR DESCRIPTION
The validation on the number of calls in Talk broke this migration.