### PR TITLE
Add a bit of responsiveness. (refs #128)

### DIFF
--- a/app/assets/stylesheets/pages/homepage.scss
+++ b/app/assets/stylesheets/pages/homepage.scss
@@ -19,22 +19,26 @@
   section {
     margin: 40% 0 10em;
     text-align: center;
-
+    background-color: rgba(255,255,255,0.8);
+    
     h1 {
-      color: white;
+      color: #222;
     }
 
     .hint {
-      color: white;
+      color: #222;
     }
   }
 
   .socialmedia {
     float: right;
-    padding-bottom: 10px;
+    position: fixed;
+    top: 0em;
+    right: 1em;
 
     .wrapper {
       display: inline-block;
     }
   }
 }
+

--- a/app/views/authentications/index.html.erb
+++ b/app/views/authentications/index.html.erb
@@ -16,12 +16,8 @@
     </p>
   </section>
 
-  <div class="socialmedia">
-    <div class="wrapper">
-      <div class="fb-like" data-href="http://cfp.eurucamp.org" data-send="false" data-layout="button_count" data-width="450" data-show-faces="false"></div>
-    </div>
-    <div class="wrapper">
-      <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://cfp.eurucamp.org" data-text="eurucamp call for proposals" data-via="eurucamp" data-related="eurucamp">Tweet</a>
-    </div>
+  <div class="socialmedia show-for-large-up">
+      <div class="warpper"><div class="fb-like" data-href="http://cfp.eurucamp.org" data-send="false" data-layout="button_count" data-width="450" data-show-faces="false"></div></div>
+      <div class="wrapper"><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://cfp.eurucamp.org" data-text="eurucamp call for proposals" data-via="eurucamp" data-related="eurucamp">Tweet</a></div>
   </div>
 </div>

--- a/app/views/main/_footer.html.erb
+++ b/app/views/main/_footer.html.erb
@@ -4,4 +4,4 @@
     <%# render 'main/counters' %>
   </div>
 </footer>
-<div class="hosted_by"></div>
+<div class="hosted_by show-for-large-up"></div>


### PR DESCRIPTION
* Tint the login background
* Hide the Shellycloud banner
* Pin Socialism to the top right corner

It might not be strictly responsive but it gets the job done:

![eurucamp-cf-xl](https://cloud.githubusercontent.com/assets/51264/6860123/f5bd3480-d423-11e4-972a-a52af99cc6fa.png)
![eurucamp-cf-l](https://cloud.githubusercontent.com/assets/51264/6860122/f5b7d9e0-d423-11e4-8fdd-74615c90a1f3.png)
![eurucamp-cf-s](https://cloud.githubusercontent.com/assets/51264/6860121/f45466cc-d423-11e4-9f36-5fadfb3312cb.png)