### PR TITLE
134 fix unique constraint error

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -21,15 +21,19 @@ class TalksController < ApplicationController
   end
 
   def create
-    @talk = current_user.talks.new(talk_params)
+    @talk = current_user.talks.new(talk_params.except(:user_attributes))
     @talk.track = 'Test'
-    if talk_params[:user_attributes]
-      @talk.user_attributes = talk_params[:user_attributes]
-    end
-
     if @talk.save
-      notify_excited_organizers
-      redirect_to @talk, notice: I18n.t('papers.create.success')
+      if talk_params[:user_attributes]
+        @talk.user_attributes = talk_params[:user_attributes]
+      end
+      if @talk.save
+        notify_excited_organizers
+        redirect_to @talk, notice: I18n.t('papers.create.success')
+      else
+        @open_calls = Call.open
+        render :new
+      end
     else
       @open_calls = Call.open
       render :new

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -27,7 +27,7 @@ class TalksController < ApplicationController
       notify_excited_organizers
       redirect_to @talk, notice: I18n.t('papers.create.success')
     else
-      render_enw_with_open_calls
+      render_new_with_open_calls
     end
   end
 

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -23,20 +23,11 @@ class TalksController < ApplicationController
   def create
     @talk = current_user.talks.new(talk_params.except(:user_attributes))
     @talk.track = 'Test'
-    if @talk.save
-      if talk_params[:user_attributes]
-        @talk.user_attributes = talk_params[:user_attributes]
-      end
-      if @talk.save
-        notify_excited_organizers
-        redirect_to @talk, notice: I18n.t('papers.create.success')
-      else
-        @open_calls = Call.open
-        render :new
-      end
+    if @talk.save && update_user_params
+      notify_excited_organizers
+      redirect_to @talk, notice: I18n.t('papers.create.success')
     else
-      @open_calls = Call.open
-      render :new
+      render_enw_with_open_calls
     end
   end
 
@@ -58,6 +49,18 @@ class TalksController < ApplicationController
   end
 
   private
+
+  def update_user_params
+    if talk_params[:user_attributes]
+      @talk.user_attributes = talk_params[:user_attributes]
+    end
+    @talk.save
+  end
+
+  def render_new_with_open_calls
+    @open_calls = Call.open
+    render :new
+  end
 
   def notify_excited_organizers
     ProposalsMailer.created(@talk.title, talk_url(@talk)).deliver_now

--- a/test/functional/talks_controller_test.rb
+++ b/test/functional/talks_controller_test.rb
@@ -68,4 +68,23 @@ class TalksControllerTest < ActionController::TestCase
 
     assert_redirected_to talks_path
   end
+
+  test 'should create talk and not fail with PG::UniqueViolation' do
+    call_id = calls(:one).id.to_s
+    post :create, talk: {
+           "title"=>"asdfsfd",
+           "public_description"=>"fasfsad",
+           "private_description"=>"fasdfasf",
+           "time_slot"=>"30 minutes",
+           "mentor_name"=>"",
+           "mentors_can_read"=>"1",
+           "terms_and_conditions"=>"1",
+           "user_attributes"=> {
+             "gender"=>"",
+             "mentor"=>"0",
+             "bio"=>""
+           },
+           "call_ids"=> [call_id, ""]
+         }
+  end
 end


### PR DESCRIPTION
This PR resolves the issue described in #134.
Under unknown circumstances a Unique Constraint Violation is raised when attempted create a talk and update the user attributes in one step.
This does it in two steps now. At first the talk is created and when this succeeds, user attributes are updated.
