### PR TITLE
Replace spaces with unbreakable spaces in the guide after and before …

### DIFF
--- a/app/views/pages/guide.html.erb
+++ b/app/views/pages/guide.html.erb
@@ -8,7 +8,7 @@ If necessary, differences are clearly marked as such.</p>
 <p>We want to encourage new speakers to get on stage or experienced speakers to try out something new. Never been on stage or thinking about changing the main topic of your speaking efforts? We are your conference!</p>
 
 <h3 id="topics">Topics for eurucamp</h3>
-<p>To get a feel for what we might be interested in hearing about, take a look at the programme from previous years ( <a href="http://2014.eurucamp.org/speakers">2014</a> | <a href="http://2013.eurucamp.org/speakers">2013</a> | <a href="http://2012.eurucamp.org/speakers">2012</a> | <a href="http://2011.eurucamp.org/#conference">2011</a> ).</p>
+<p>To get a feel for what we might be interested in hearing about, take a look at the programme from previous years ( <a href="http://2014.eurucamp.org/speakers">2014</a> | <a href="http://2013.eurucamp.org/speakers">2013</a> | <a href="http://2012.eurucamp.org/speakers">2012</a> | <a href="http://2011.eurucamp.org/#conference">2011</a> ).</p>
 <p>eurucamp is a Ruby event. We are looking for Ruby topics or topics that would interest Rubyists. The Ruby community is a very curious one, so talks about interesting new developments in the world of programming are welcome. Topics covering the social aspects of programming are also met with interest.</p>
 <p>Rails talks are welcome, but we want to cover a broad range of topics, so those will be limited.</p>
 <p>We also accept non-talk proposals, like workshops and moderated discussions. You can select your format in the CFP process.</p>


### PR DESCRIPTION
…opening and closing parenthesis.

This would solve the issue of the flying parenthesis all alone on its line.