### PR TITLE
update twitter avatar-link, fixes #141

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,7 +21,7 @@ module ApplicationHelper
   end
 
   def twitter_avatar_url(handle)
-    "https://twitter.com/api/users/profile_image/#{handle}?size=bigger"
+    "http://twitter.com/{handle}/profile_image/?size=bigger"
   end
 
   def avatar_url(user, size = 64)


### PR DESCRIPTION
The api used has be discontinued and is no longer available, thus resulting in broken profile-pictures as described in issue #141. The updated link gets the profile-image from twitter without using their newer api to circumvent the oauth requirement.
